### PR TITLE
Add cmake from kitware

### DIFF
--- a/istioproxy/workspace.go
+++ b/istioproxy/workspace.go
@@ -137,8 +137,8 @@ RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-
 FROM ubuntu:20.04 AS linux_headers_arm64
 RUN apt-get -q update && apt-get install -yqq --no-install-recommends curl ca-certificates
 RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-aarch64.tar.gz && \
-  tar -xzf cmake-3.29.2-linux-aarch64_64.tar.gz -C /usr/ && \
-  rm cmake-3.29.2-linux-aarch64_64.tar.gz
+  tar -xzf cmake-3.29.2-linux-aarch64.tar.gz -C /usr/ && \
+  rm cmake-3.29.2-linux-aarch64.tar.gz
 
 FROM linux_headers_${TARGETARCH} AS linux_headers
 RUN apt-get -q update && apt-get install -yqq --no-install-recommends linux-libc-dev

--- a/istioproxy/workspace.go
+++ b/istioproxy/workspace.go
@@ -131,14 +131,15 @@ ARG IMG
 FROM ubuntu:20.04 AS linux_headers_amd64
 RUN apt-get -q update && apt-get install -yqq --no-install-recommends curl ca-certificates
 RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.tar.gz && \
-  tar -xzf cmake-3.29.2-linux-x86_64.tar.gz -C /usr/ && \
+  tar -xzf cmake-3.29.2-linux-x86_64.tar.gz -C /usr/  --strip-components=1 && \
   rm cmake-3.29.2-linux-x86_64.tar.gz
 
 FROM ubuntu:20.04 AS linux_headers_arm64
 RUN apt-get -q update && apt-get install -yqq --no-install-recommends curl ca-certificates
 RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-aarch64.tar.gz && \
-  tar -xzf cmake-3.29.2-linux-aarch64.tar.gz -C /usr/ && \
+  tar -xzvf cmake-3.29.2-linux-aarch64.tar.gz -C /usr/ --strip-components=1 && \
   rm cmake-3.29.2-linux-aarch64.tar.gz
+
 
 FROM linux_headers_${TARGETARCH} AS linux_headers
 RUN apt-get -q update && apt-get install -yqq --no-install-recommends linux-libc-dev

--- a/istioproxy/workspace.go
+++ b/istioproxy/workspace.go
@@ -136,8 +136,15 @@ RUN apt-get -q update && apt-get install -yqq --no-install-recommends linux-libc
 
 FROM $IMG
 COPY --from=linux_headers /usr/include/linux/tcp.h /usr/include/linux/tcp.h
+# Get cmake from kitware
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' |  tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
 RUN su-exec 0:0 apt-get -o APT::Get::AllowUnauthenticated=true -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true -q update && \
   su-exec 0:0 apt-get -o APT::Get::AllowUnauthenticated=true -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true install -yqq --no-install-recommends rsync cmake
+
+RUN apt-get download cmake && dpkg -i --force-all --ignore-depends=libc cmake*.deb
+
 ENV BAZEL_BUILD_ARGS="`+remoteCache+`"`),
 		os.ModePerm); err != nil {
 		return err


### PR DESCRIPTION
This patch adds cmake from kitware

```
% docker run -ti docker.io/library/leo:builder-1 sh
# cmake
Usage

  cmake [options] <path-to-source>
  cmake [options] <path-to-existing-build>
  cmake [options] -S <path-to-source> -B <path-to-build>

Specify a source directory to (re-)generate a build system for it in the
current working directory.  Specify an existing build directory to
re-generate its build system.

Run 'cmake --help' for more information.
```